### PR TITLE
Since the CommandConverter takes strings as an input value, they should

### DIFF
--- a/Classes/Netlogix/Cqrs/Property/TypeConverter/CommandConverter.php
+++ b/Classes/Netlogix/Cqrs/Property/TypeConverter/CommandConverter.php
@@ -30,7 +30,7 @@ class CommandConverter extends PersistentObjectConverter
         if (!is_subclass_of($targetType, $this->targetType)) {
             return false;
         }
-        if (!isset($source['__identity'])) {
+        if (is_array($source) && !isset($source['__identity'])) {
             return false;
         }
         return true;


### PR DESCRIPTION
be used as conversion source as well.
