### PR TITLE
[BUGFIX] Persist CommandLogEntries using DBAL

### DIFF
--- a/Classes/Netlogix/Cqrs/Log/CommandLogEntry.php
+++ b/Classes/Netlogix/Cqrs/Log/CommandLogEntry.php
@@ -113,6 +113,14 @@ class CommandLogEntry
     }
 
     /**
+     * @param int $status
+     */
+    public function setStatus($status)
+    {
+        $this->status = $status;
+    }
+
+    /**
      * @return ExceptionData
      */
     public function getException()

--- a/Classes/Netlogix/Cqrs/Log/CommandLogEntryRepository.php
+++ b/Classes/Netlogix/Cqrs/Log/CommandLogEntryRepository.php
@@ -6,19 +6,36 @@ namespace Netlogix\Cqrs\Log;
  * This file is part of the Netlogix.Cqrs package.
  */
 
+use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Types\Type;
+use Doctrine\ORM\EntityManager;
 use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Persistence\Exception\IllegalObjectTypeException;
 use Neos\Flow\Persistence\Repository;
 use Netlogix\Cqrs\Command\AbstractCommand;
 
 /**
+ * CommandLogEntries are persisted and updated using DBAL, because:
+ * * Using $persistenceManager->persistAll() will persist other modified entities
+ * * Using $entityManager->flush($commandLogEntry) will persist the entry, but discard all other working changes
+ * * Persisting the log in shutdownObject() will cause problems with sub-processing (Netlogix.Cqrs.RabbitMq)
+ *
  * @Flow\Scope("singleton")
  */
 class CommandLogEntryRepository extends Repository
 {
+
     /**
      * @var string
      */
     const ENTITY_CLASSNAME = CommandLogEntry::class;
+
+    /**
+     * @Flow\Inject
+     * @var ObjectManager
+     */
+    protected $entityManager;
 
     /**
      * @param AbstractCommand $command
@@ -35,4 +52,64 @@ class CommandLogEntryRepository extends Repository
             ->execute()
             ->getFirst();
     }
+
+    public function add($object)
+    {
+        if (!is_object($object) || !($object instanceof $this->entityClassName)) {
+            $type = (is_object($object) ? get_class($object) : gettype($object));
+            throw new IllegalObjectTypeException('The value given to add() was ' . $type . ' , however the ' . get_class($this) . ' can only store ' . $this->entityClassName . ' instances.',
+                1298403438);
+        }
+        assert($object instanceof CommandLogEntry);
+
+        $connection = $this->getConnection();
+        $classMetaData = $this->entityManager->getClassMetadata(get_class($object));
+
+        $connection->insert($classMetaData->getTableName(), [
+            'commandid' => $object->getCommandId(),
+            'commandtype' => $object->getCommandType(),
+            'executiondateandtime' => $object->getExecutionDateAndTime(),
+            'command' => serialize($object->getCommand()),
+            'status' => $object->getStatus(),
+            'exception' => serialize($object->getException())
+        ], [
+            Type::STRING,
+            Type::STRING,
+            Type::DATETIME,
+            Type::BLOB,
+            Type::INTEGER,
+            Type::BLOB,
+        ]);
+    }
+
+    public function update($object)
+    {
+        if (!is_object($object) || !($object instanceof $this->entityClassName)) {
+            $type = (is_object($object) ? get_class($object) : gettype($object));
+            throw new IllegalObjectTypeException('The value given to update() was ' . $type . ' , however the ' . get_class($this) . ' can only store ' . $this->entityClassName . ' instances.',
+                1249479625);
+        }
+        assert($object instanceof CommandLogEntry);
+
+        $connection = $this->getConnection();
+        $classMetaData = $this->entityManager->getClassMetadata(get_class($object));
+
+        $connection->update($classMetaData->getTableName(), [
+            'status' => $object->getStatus(),
+            'exception' => serialize($object->getException()),
+        ], [
+            'commandid' => $object->getCommandId()
+        ], [
+            Type::STRING,
+            Type::BLOB,
+        ]);
+    }
+
+    protected function getConnection(): Connection
+    {
+        assert($this->entityManager instanceof EntityManager);
+
+        return $this->entityManager->getConnection();
+    }
+
 }

--- a/Classes/Netlogix/Cqrs/Log/CommandLogger.php
+++ b/Classes/Netlogix/Cqrs/Log/CommandLogger.php
@@ -6,6 +6,7 @@ namespace Netlogix\Cqrs\Log;
  * This file is part of the Netlogix.Cqrs package.
  */
 
+use Exception;
 use Neos\Flow\Annotations as Flow;
 use Netlogix\Cqrs\Command\AbstractCommand;
 
@@ -14,6 +15,7 @@ use Netlogix\Cqrs\Command\AbstractCommand;
  */
 class CommandLogger
 {
+
     /**
      * @var CommandLogEntryRepository
      * @Flow\Inject
@@ -21,18 +23,12 @@ class CommandLogger
     protected $commandLogEntryRepository;
 
     /**
-     * @var \Doctrine\Common\Persistence\ObjectManager
-     * @Flow\Inject
-     */
-    protected $entityManager;
-
-    /**
      * Log the given command
      *
      * @param AbstractCommand $command
-     * @param \Exception $exception
+     * @param Exception $exception
      */
-    public function logCommand(AbstractCommand $command, \Exception $exception = null)
+    public function logCommand(AbstractCommand $command, Exception $exception = null)
     {
         $commandLogEntry = $this->commandLogEntryRepository->findOneByCommand($command);
         $isNewObject = !$commandLogEntry;
@@ -41,6 +37,7 @@ class CommandLogger
             $commandLogEntry = new CommandLogEntry($command);
         }
 
+        $commandLogEntry->setStatus($command->getStatus());
         $commandLogEntry->setException($exception === null ? null : new ExceptionData($exception));
 
         if ($isNewObject) {
@@ -48,7 +45,6 @@ class CommandLogger
         } else {
             $this->commandLogEntryRepository->update($commandLogEntry);
         }
-        $this->entityManager->flush($commandLogEntry);
     }
 
 }

--- a/Tests/Unit/Command/CommandBusTest.php
+++ b/Tests/Unit/Command/CommandBusTest.php
@@ -63,7 +63,7 @@ class CommandBusTest extends \Neos\Flow\Tests\UnitTestCase {
 		$mockCommandHandler = $this->getMockBuilder(CommandHandlerInterface::class)->getMockForAbstractClass();
 		
 		$mockCommandLogger = $this->getMockBuilder(CommandLogger::class)->getMock();
-		$mockCommandLogger->expects($this->once())->method('logCommand')->with($mockCommand);
+		$mockCommandLogger->expects($this->exactly(2))->method('logCommand')->with($mockCommand);
 
 		$commandBus = new CommandBus();
 		$this->inject($commandBus, 'commandHandlers', array($mockCommandHandler));

--- a/Tests/Unit/Log/CommandLogEntryTest.php
+++ b/Tests/Unit/Log/CommandLogEntryTest.php
@@ -21,7 +21,11 @@ class CommandLogEntryTest extends \Neos\Flow\Tests\UnitTestCase {
 
 	public function testCommandTypeIsStoredInLogEntry() {
 		/** @var AbstractCommand|\PHPUnit_Framework_MockObject_MockObject $mockCommand */
-		$mockCommand = $this->getMockBuilder(AbstractCommand::class)->disableOriginalConstructor()->setMockClassName('CommandTestMock')->getMock();
+		$mockCommand = $this->getMockBuilder(AbstractCommand::class)
+            ->disableOriginalConstructor()
+            ->setMockClassName('CommandTestMock')
+            ->setMethodsExcept(['getCommandType'])
+            ->getMock();
 
 		$commandLogEntry = new CommandLogEntry($mockCommand);
 		$this->assertEquals('CommandTestMock', $commandLogEntry->getCommandType());


### PR DESCRIPTION
Using $entityManager->flush($commandLogEntry) discards all working changes
in the UnitOfWork, leading to data loss