### PR TITLE
BUGFIX: Fix invalid assert in CommandLogEntryRepository

### DIFF
--- a/Classes/Netlogix/Cqrs/Log/CommandLogEntryRepository.php
+++ b/Classes/Netlogix/Cqrs/Log/CommandLogEntryRepository.php
@@ -32,7 +32,7 @@ class CommandLogEntryRepository extends Repository
     const ENTITY_CLASSNAME = CommandLogEntry::class;
 
     /**
-     * @Flow\Inject
+     * @Flow\Inject(lazy=false)
      * @var ObjectManager
      */
     protected $entityManager;


### PR DESCRIPTION
Disable lazy property injection on ObjectManager in CommandLogEntryRepository to prevent invalid assert in getConnection().